### PR TITLE
Fix Use of exit() or quit()

### DIFF
--- a/inference.py
+++ b/inference.py
@@ -10,6 +10,7 @@ import argparse
 import time
 import re
 import os
+import sys
 import csv
 from datetime import datetime
 from pathlib import Path
@@ -717,4 +718,4 @@ def main():
 
 
 if __name__ == "__main__":
-    exit(main())
+    sys.exit(main())


### PR DESCRIPTION
The `exit` and `quit` "functions" are actually `site.Quitter` objects and are loaded, at interpreter start up, from `inference.py` However, if the interpreter is started with the `-S` flag, or a custom `inference.py` is used then `exit` and `quit` may not be present.

Fixes Use `sys.exit()` instead of `exit()` in the `__main__` guard.

Best fix (without changing functionality):
1. Add `import sys` near the other imports in `inference.py`.
2. Replace `exit(main())` with `sys.exit(main())` at the bottom of the file.

This preserves exact current behavior (propagating `main()` return code as process exit code) while removing dependence on the `site` module’s `Quitter` object.


## References
 [Command line and environment](https://docs.python.org/using/cmdline.html#cmdoption-S)
 [Site-specific configuration hook](https://docs.python.org/library/site.html#module-site)